### PR TITLE
four columns on children's page

### DIFF
--- a/app/assets/stylesheets/appcustom.css.scss
+++ b/app/assets/stylesheets/appcustom.css.scss
@@ -18,8 +18,12 @@ a:hover {
   a {
       text-decoration: none;
   }
+  th {display: table-header-group;}
 }
 
+.pagebreak {
+    page-break-before: always;
+}
 
 
 .success {
@@ -156,6 +160,30 @@ a:hover {
 
 table#households-listing tr td {
     padding-right: 40px;
+}
+
+.wrap-cells-to-next-page {
+    display: block;
+    thead {
+        display: table-header-group !important;
+            text-align: left;
+            font-weight: normal !important;
+            padding-bottom: 40px !important;
+            display: block;
+            font-size: 20px;
+            -webkit-margin-before: 0.83em;
+            -webkit-margin-after: 0.83em;
+            -webkit-margin-start: 0px;
+            -webkit-margin-end: 0px;
+            break-inside: avoid;
+    }
+    tbody { 
+        display: table-row-group;
+        
+    }
+    td {
+        display: inline-block;
+    }
 }
 
 .loggedinbox {

--- a/app/views/churches/_member_pages_and_matrices.html.erb
+++ b/app/views/churches/_member_pages_and_matrices.html.erb
@@ -18,8 +18,6 @@
    <% end -%>
    </table>
 
-   <div class="pagenum">Page <%= pagedata[:pagenum] if !out_of_area %> <%= @members_pages_count if out_of_area %> <%= page_num_extra if defined?(page_num_extra) %>
-   
-   </div>
+   <div class="pagenum">Page <%= pagedata[:pagenum] if !out_of_area %> <%= @members_pages_count if out_of_area %> <%= page_num_extra if defined?(page_num_extra) %></div>
 </div>
 <% end -%>

--- a/app/views/churches/directory.html.erb
+++ b/app/views/churches/directory.html.erb
@@ -14,19 +14,20 @@
 	<%= render :partial => 'member_pages_and_matrices', :locals => { :title => "#{@church.short_name_prioritized} Members Out of Area as of #{Date.today.strftime('%B %-d, %Y')}", :memberlist => @church.moved_members, :rows_per_page => @rows_per_page, :cols_per_page => @cols_per_page, :show_details => true, :out_of_area => true } %>
 
 	<div class="members-page" id="members-page-households">
-		<h2><%= @church.short_name_prioritized %> Households and Children</h2>
-
-		<table id="households-listing" style="">
+		<h2><%= @church.short_name_prioritized %> Households and Children as of <%= Date.today.strftime('%B %-d, %Y') %></h2>
+		<table id="households-listing" class="wrap-cells-to-next-page">
+			
+			<tbody>
 			<tr>
-				<td valign="top" align="left">
+				<td valign="top" align="left" style="max-width:220px;max-height:1150px;">
 		<% @hh_lines_iter = 0 -%>
-		<% @hh_lines_per_col = 45 -%>
+		<% @hh_lines_per_col = 52 -%>
 		<% @church.sorted_households.each do |hh| %>
 		 <% unless hh[:children].empty? %>
 		
 		 <% if @hh_lines_iter > @hh_lines_per_col %>
 		        </td>
-		        <td valign="top" align="left">
+		        <td valign="top" align="left" style="max-width:220px;max-height:1150px;">
 			  <% @hh_lines_iter = 0 %>
 		 <% end %>
 		 <div class="household">
@@ -46,5 +47,6 @@
 		<% end -%>
 				</td>
 			</tr>
+			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
The table used to resize to fit all of the children on one page, now we stick to four columns and overflow onto the next page.